### PR TITLE
상세 배너 이미지 비율, 최소 높이 추가

### DIFF
--- a/src/app/details/[id]/components/banner/Banner.module.css
+++ b/src/app/details/[id]/components/banner/Banner.module.css
@@ -1,7 +1,10 @@
 .BannerContentWrapper {
   position: relative;
   width: calc(100% + 3rem);
-  height: 380px;
+  height: auto;
+  min-height: 240px;
+  max-height: 400px;
+  aspect-ratio: 16 / 9;
   overflow: hidden;
   margin: -1.5rem;
 }


### PR DESCRIPTION
캐러젤 내부 이미지 높이: 80px -> 배너 최소 높이 : 240px (3배)

![image](https://github.com/user-attachments/assets/0ee64742-b14a-4607-8526-eaaf3305221d)
